### PR TITLE
#164625824 Fix swagger host link

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -12,7 +12,7 @@
        "Author": "Gilles Kagarama"
      }
    },
-   "host": "https://epicmailbox.herokuapp.com",
+   "host": "epicmailbox.herokuapp.com",
    "basePath": "/",
   "schemes": [
    "http",


### PR DESCRIPTION
## What does this PR do?
Fix swagger host link

## Description
- Swagger does not allow host with **http** or **https** in the URL, This PR fixes the host link by removing https from the link

## How should this be manually tested?
Visit: [https://epicmailbox.herokuapp.com/docs](https://epicmailbox.herokuapp.com/docs)

## What are the relevant pivotal tracker stories?
###164625824